### PR TITLE
Add PySide6 HMI example

### DIFF
--- a/indux_hmi/README.md
+++ b/indux_hmi/README.md
@@ -1,0 +1,24 @@
+# Indux HMI Example
+
+This is a minimal example of a Human-Machine Interface built with PySide6 and QML.
+It demonstrates a modular layout inspired by the Indux OS design style.
+
+## Structure
+```
+indux_hmi/
+├── main.py
+├── backend.py
+├── qml/
+│   ├── main.qml
+│   └── components/
+│       ├── Sidebar.qml
+│       ├── StatusPanel.qml
+│       ├── AlertCard.qml
+│       └── TopBar.qml
+├── resources/
+│   └── logo.png
+├── styles/
+│   └── theme.qml
+```
+
+Run `python main.py` to launch the interface.

--- a/indux_hmi/backend.py
+++ b/indux_hmi/backend.py
@@ -1,0 +1,23 @@
+from PySide6.QtCore import QObject, Slot, Signal, Property
+
+class MachineBackend(QObject):
+    def __init__(self):
+        super().__init__()
+        self._status = "Running"
+        self._alerts = ["Check pressure", "Lubrication overdue"]
+
+    statusChanged = Signal()
+    alertsChanged = Signal()
+
+    @Property(str, notify=statusChanged)
+    def status(self):
+        return self._status
+
+    @Property("QStringList", notify=alertsChanged)
+    def alerts(self):
+        return self._alerts
+
+    @Slot()
+    def acknowledgeAll(self):
+        self._alerts.clear()
+        self.alertsChanged.emit()

--- a/indux_hmi/main.py
+++ b/indux_hmi/main.py
@@ -1,0 +1,17 @@
+from PySide6.QtWidgets import QApplication
+from PySide6.QtQml import QQmlApplicationEngine
+from backend import MachineBackend
+import sys
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+
+    engine = QQmlApplicationEngine()
+    backend = MachineBackend()
+    engine.rootContext().setContextProperty("machineBackend", backend)
+
+    engine.load("qml/main.qml")
+    if not engine.rootObjects():
+        sys.exit(-1)
+
+    sys.exit(app.exec())

--- a/indux_hmi/qml/components/AlertCard.qml
+++ b/indux_hmi/qml/components/AlertCard.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: parent.width
+    height: 60
+    color: "#ff4444"
+    radius: 8
+
+    Label {
+        anchors.centerIn: parent
+        text: alertText
+        color: "white"
+    }
+
+    property string alertText: "Alert"
+}

--- a/indux_hmi/qml/components/Sidebar.qml
+++ b/indux_hmi/qml/components/Sidebar.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 200
+    color: "#1e1e1e"
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+
+    Column {
+        spacing: 20
+        anchors.centerIn: parent
+
+        Label {
+            text: "⚙️ Machine"
+            color: "white"
+        }
+        Label {
+            text: "📊 Status"
+            color: "white"
+        }
+        Label {
+            text: "🧠 AI Tools"
+            color: "white"
+        }
+    }
+}

--- a/indux_hmi/qml/components/StatusPanel.qml
+++ b/indux_hmi/qml/components/StatusPanel.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 300
+    height: 200
+    color: "#2d2d2d"
+    radius: 16
+
+    Label {
+        anchors.centerIn: parent
+        text: statusText
+        font.pointSize: 24
+        color: "lightgreen"
+    }
+
+    property string statusText: "Idle"
+}

--- a/indux_hmi/qml/components/TopBar.qml
+++ b/indux_hmi/qml/components/TopBar.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: parent.width
+    height: 50
+    color: "#333333"
+
+    Label {
+        anchors.centerIn: parent
+        text: title
+        font.pointSize: 20
+        color: "white"
+    }
+
+    property string title: "TopBar"
+}

--- a/indux_hmi/qml/main.qml
+++ b/indux_hmi/qml/main.qml
@@ -1,0 +1,49 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import "components"
+import "../styles/theme.qml" as Theme
+
+ApplicationWindow {
+    visible: true
+    width: 1200
+    height: 700
+    title: "Indux HMI Demo"
+    color: Theme.background
+
+    Sidebar {
+        id: sidebar
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 20
+
+        TopBar {
+            title: "Dashboard"
+        }
+
+        RowLayout {
+            spacing: 24
+            StatusPanel {
+                statusText: machineBackend.status
+            }
+
+            ListView {
+                model: machineBackend.alerts
+                delegate: AlertCard {
+                    alertText: modelData
+                }
+                width: 400
+                height: 300
+            }
+        }
+
+        Button {
+            text: "Acknowledge All"
+            onClicked: machineBackend.acknowledgeAll()
+        }
+    }
+}

--- a/indux_hmi/styles/theme.qml
+++ b/indux_hmi/styles/theme.qml
@@ -1,0 +1,8 @@
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    property color background: "#121212"
+    property color accent: "#00adb5"
+    property color text: "#eeeeee"
+}


### PR DESCRIPTION
## Summary
- provide a small PySide6 + QML demonstration app under `indux_hmi`
- include backend code and reusable QML components

## Testing
- `python -m py_compile indux_hmi/*.py`
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684064722410832c8ef5a8a084664879